### PR TITLE
Changed submission form to use a placeholder in URL field

### DIFF
--- a/View/Resource.hs
+++ b/View/Resource.hs
@@ -31,7 +31,7 @@ resourceForm uid = renderBootstrap3 BootstrapInlineForm $ (,)
 resourceEntityForm :: UserId -> AForm Handler Resource
 resourceEntityForm uid = Resource
     <$> areq textField "Title" Nothing
-    <*> areq urlField "Url" (Just "http://")
+    <*> areq urlField ("Url" {fsAttrs = [("placeholder", "http://")]}) Nothing
     <*> aopt textField "Primary Author (optional)" Nothing
     <*> aopt intField "Year (optional)" Nothing
     <*> areq resourceTypeField "Type" Nothing


### PR DESCRIPTION
Previously it was easy to input incorrect URLs by pasting into the URL field and not removing the default value. This means that pasting into the field will give the expected behaviour. 
