### PR TITLE
"Recently added" sort order for resources.

### DIFF
--- a/src/Model/Browse.hs
+++ b/src/Model/Browse.hs
@@ -15,15 +15,17 @@ data BrowseByLink
 
 data SortBy
     = SortByAZ
-    | SortByCountUp   -- lowest count at top
-    | SortByCountDown -- highest count at top
-    | SortByYearUp    -- earliest year at top
-    | SortByYearDown  -- latest year at top
+    | SortByCountUp        -- lowest count at top
+    | SortByCountDown      -- highest count at top
+    | SortByYearUp         -- earliest year at top
+    | SortByYearDown       -- latest year at top
+    | SortByRecentlyAdded  -- latest submission at top
     deriving Eq
 
 instance Show SortBy where
-    show SortByAZ        = "a-z"
-    show SortByCountUp   = "count-up"
-    show SortByCountDown = "count-down"
-    show SortByYearUp    = "year-up"
-    show SortByYearDown  = "year-down"
+    show SortByAZ             = "a-z"
+    show SortByCountUp        = "count-up"
+    show SortByCountDown      = "count-down"
+    show SortByYearUp         = "year-up"
+    show SortByYearDown       = "year-down"
+    show SortByRecentlyAdded  = "recently-added"

--- a/src/View/Browse.hs
+++ b/src/View/Browse.hs
@@ -152,6 +152,8 @@ sortResBarWidget SortByYearUp = do
         |
         <a .bar-link #so-res-year-down href=@?{(route, addGetParam ("sort-res", T.pack (show SortByYearDown)) params)}>year#
           <span .arr>&#9650;
+        |
+        <a .bar-link #so-res-recently-added href=@?{(route, addGetParam ("sort-res", T.pack (show SortByRecentlyAdded)) params)}>recently added
     |]
     sortResBarCSS
     toWidget [cassius|
@@ -166,10 +168,28 @@ sortResBarWidget SortByYearDown = do
         |
         <a .bar-link #so-res-year-up href=@?{(route, addGetParam ("sort-res", T.pack (show SortByYearUp)) params)}>year#
           <span .arr>&#9660;
+        |
+        <a .bar-link #so-res-recently-added href=@?{(route, addGetParam ("sort-res", T.pack (show SortByRecentlyAdded)) params)}>recently added
     |]
     sortResBarCSS
     toWidget [cassius|
       #so-res-year-up
+        font-weight: bold
+    |]
+sortResBarWidget SortByRecentlyAdded = do
+    (route, params) <- handlerToWidget getCurrentRouteWithGetParams
+    [whamlet|
+      <div .bar .sort-res-bar>sort resources by: #
+        <a .bar-link #so-res-az href=@?{(route, addGetParam ("sort-res", T.pack (show SortByAZ)) params)}>a-z
+        |
+        <a .bar-link #so-res-year-down href=@?{(route, addGetParam ("sort-res", T.pack (show SortByYearDown)) params)}>year#
+          <span .arr>&#9660;
+        |
+        <a .bar-link #so-res-recently-added href=@?{(route, addGetParam ("sort-res", T.pack (show SortByRecentlyAdded)) params)}>recently added
+    |]
+    sortResBarCSS
+    toWidget [cassius|
+      #so-res-recently-added
         font-weight: bold
     |]
 sortResBarWidget _ = do
@@ -180,6 +200,8 @@ sortResBarWidget _ = do
         |
         <a .bar-link #so-res-year-down href=@?{(route, addGetParam ("sort-res", T.pack (show SortByYearDown)) params)}>year#
           <span .arr>&#9660;
+        |
+        <a .bar-link #so-res-recently-added href=@?{(route, addGetParam ("sort-res", T.pack (show SortByRecentlyAdded)) params)}>recently added
     |]
     sortResBarCSS
     toWidget [cassius|


### PR DESCRIPTION
A "recently added" sort order provides a cheap way of knowing what is new at dohaskell by combining it with the "list all" option. Note that I implemented this in the laziest way possible -- there is no reverse "earliest added" option, and the comparison is based on mere resource ids. 